### PR TITLE
Stop lazyloading the plausible-tracker package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ember install ember-plausible
 
 How it works
 ------------------------------------------------------------------------------
-`ember-plausible` provides a thin wrapper around the [plausible-tracker](https://github.com/plausible/plausible-tracker) npm package. It doesn't use the standalone Plausible script tag that is traditionally used when integrating Plausible. The tracker code will be part of the app bundle which has the benefit that ad-blockers can't block it. The package itself is lazy-loaded so it will only be downloaded by the browser if Plausible is actually enabled.
+`ember-plausible` provides a thin wrapper around the [plausible-tracker](https://github.com/plausible/plausible-tracker) npm package. It doesn't use the standalone Plausible script tag that is traditionally used when integrating Plausible. The tracker code will be part of the app bundle which has the benefit that ad-blockers can't block it.
 
 Configuration
 ------------------------------------------------------------------------------
@@ -126,9 +126,6 @@ Enable Plausible if it isn't already. This is only needed if you explicitly disa
 
 ###### options: `object`
 The options object to initialize Plausible with. These are _almost_ the same  as the [configuration options](#Configuration-options) in the `config/environment.js` file. The `enabled` option isn't needed here.
-
-###### Returns
-A `Promise` which resolves when the Plausible service is fully functional.
 
 ##### trackPageview
 Send a Pageview event (for the current page) to the API. This is useful if you want complete control over when pageview events are sent to the server.

--- a/addon/services/plausible.js
+++ b/addon/services/plausible.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
+import Plausible from 'plausible-tracker';
 
 // These default options extend the default options from the plausible-tracker package and mimics the behavior of the official script:
 // https://plausible-tracker.netlify.app/globals#plausibleinitoptions
@@ -25,7 +26,7 @@ export default class PlausibleService extends Service {
     return Boolean(this._autoOutboundTrackingCleanup);
   }
 
-  async enable(options = {}) {
+  enable(options = {}) {
     if (!this.isEnabled) {
       let plausibleOptions = {
         ...DEFAULT_OPTIONS,
@@ -34,9 +35,7 @@ export default class PlausibleService extends Service {
 
       let domain = handleDomainConfig(plausibleOptions.domain);
 
-      let Plausible = await this._loadPlausible();
-
-      this._plausible = Plausible({
+      this._plausible = this._createPlausibleTracker({
         ...plausibleOptions,
         domain,
       });
@@ -104,9 +103,8 @@ export default class PlausibleService extends Service {
     }
   }
 
-  async _loadPlausible() {
-    let { default: Plausible } = await import('plausible-tracker');
-    return Plausible;
+  _createPlausibleTracker(plausibleOptions) {
+    return Plausible(plausibleOptions);
   }
 
   willDestroy() {

--- a/index.js
+++ b/index.js
@@ -2,9 +2,4 @@
 
 module.exports = {
   name: require('./package').name,
-  options: {
-    babel: {
-      plugins: [require.resolve('ember-auto-import/babel-plugin')],
-    },
-  },
 };

--- a/tests/unit/services/plausible-test.js
+++ b/tests/unit/services/plausible-test.js
@@ -11,34 +11,20 @@ module('Unit | Service | plausible', function (hooks) {
   // This means that the tests fail if `enabled` is set to true in the environment config, even if we overwrite that config in the hook.
   preventAutoPlausibleEnable(hooks);
 
-  test('it lazy-loads the plausible-tracker module', async function (assert) {
-    let plausibleService = this.owner.lookup('service:plausible');
-    sinon.spy(plausibleService, '_loadPlausible');
-
-    assert.notOk(plausibleService._plausible);
-    await plausibleService.enable({
-      domain: 'foo.test',
-    });
-
-    assert.ok(plausibleService._loadPlausible.calledOnce);
-    assert.ok(plausibleService._plausible);
-  });
-
   test('it throws an error if no domain is specified', function (assert) {
     let plausibleService = this.owner.lookup('service:plausible');
 
-    assert.rejects(
-      plausibleService.enable({}),
-      /"domain" should be a string or an array of strings/
-    );
+    assert.throws(() => {
+      plausibleService.enable({});
+    }, /"domain" should be a string or an array of strings/);
   });
 
   test('it combines an array of domains into a comma separated list', async function (assert) {
     let plausibleService = this.owner.lookup('service:plausible');
 
-    let { mockPlausible } = mockPlausiblePackage(plausibleService);
+    let mockPlausible = mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: ['foo.test', 'bar.test'],
     });
 
@@ -51,7 +37,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
     });
 
@@ -64,7 +50,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
       enableAutoPageviewTracking: false,
     });
@@ -78,7 +64,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
     });
 
@@ -91,7 +77,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
       enableAutoOutboundTracking: true,
     });
@@ -104,7 +90,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
     });
 
@@ -118,7 +104,7 @@ module('Unit | Service | plausible', function (hooks) {
 
     mockPlausiblePackage(plausibleService);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
     });
 
@@ -135,7 +121,7 @@ module('Unit | Service | plausible', function (hooks) {
     assert.equal(plausibleService._autoPageviewTrackingCleanup, null);
     assert.equal(plausibleService._autoOutboundTrackingCleanup, null);
 
-    await plausibleService.enable({
+    plausibleService.enable({
       domain: 'foo.test',
       enableAutoPageviewTracking: true,
       enableAutoOutboundTracking: true,
@@ -160,11 +146,7 @@ function mockPlausiblePackage(plausibleService) {
     enableAutoOutboundTracking: sinon.fake.returns(() => {}),
   });
 
-  let fakeLoadPlausible = sinon.fake.resolves(mockPlausible);
-  sinon.replace(plausibleService, '_loadPlausible', fakeLoadPlausible);
+  sinon.replace(plausibleService, '_createPlausibleTracker', mockPlausible);
 
-  return {
-    mockPlausible,
-    fakeLoadPlausible,
-  };
+  return mockPlausible;
 }


### PR DESCRIPTION
The package is small enough and the overhead of the dynamic import tooling increases the bundle size more than the package itself.

Closes #10 