### PR TITLE
Enable the Ember 3.20 scenario again

### DIFF
--- a/.woodpecker/.test-scenarios.yml
+++ b/.woodpecker/.test-scenarios.yml
@@ -1,5 +1,6 @@
 matrix:
   scenario:
+    - ember-lts-3.20
     - ember-lts-3.24
     - ember-release
     - ember-beta


### PR DESCRIPTION
It seems this was lost when transitioning from Drone to Woodpecker but we still support it.