### PR TITLE
Pass through `eventData` and `props`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ For more advanced use cases you can use the following options:
 ##### trackPageview
 Send a Pageview event (for the current page) to the API. This is useful if you want complete control over when pageview events are sent to the server.
 
+###### [eventData](https://plausible-tracker.netlify.app/globals#plausibleoptions) (optional): `object`
+Extra event data you want to send
+
+###### props (optional): `object`
+The properties you want to bind to the event
+
 ###### Returns
 A `Promise` which resolves when the pageview event is successfully sent.
 
@@ -137,8 +143,11 @@ Send a custom event to the API.
 ###### eventName: `string`
 The name of the custom event. This is the value that you need to use when setting up custom goals in the Plausible dashboard.
 
-###### props: `object`
-The extra data that you want to send with your custom event.
+###### props (optional): `object`
+The properties you want to bind to the event
+
+###### [eventData](https://plausible-tracker.netlify.app/globals#plausibleoptions) (optional): `object`
+Extra event data you want to send
 
 ###### Returns
 A `Promise` which resolves when the custom event is successfully sent.

--- a/addon/services/plausible.js
+++ b/addon/services/plausible.js
@@ -50,20 +50,18 @@ export default class PlausibleService extends Service {
     }
   }
 
-  trackPageview() {
+  trackPageview(eventData = {}, props = {}) {
     if (this.isEnabled) {
       return new Promise((resolve) => {
-        this._plausible.trackPageview(
-          {},
-          {
-            callback: resolve,
-          }
-        );
+        this._plausible.trackPageview(eventData, {
+          props,
+          callback: resolve,
+        });
       });
     }
   }
 
-  trackEvent(eventName, props = {}) {
+  trackEvent(eventName, props = {}, eventData = {}) {
     assert(
       assertMessage('"eventName" is required'),
       typeof eventName === 'string'
@@ -71,7 +69,11 @@ export default class PlausibleService extends Service {
 
     if (this.isEnabled) {
       return new Promise((resolve) => {
-        this._plausible.trackEvent(eventName, { props, callback: resolve });
+        this._plausible.trackEvent(
+          eventName,
+          { props, callback: resolve },
+          eventData
+        );
       });
     }
   }

--- a/tests/unit/services/plausible-test.js
+++ b/tests/unit/services/plausible-test.js
@@ -99,6 +99,36 @@ module('Unit | Service | plausible', function (hooks) {
     assert.ok(plausibleService._plausible.trackPageview.calledOnce);
   });
 
+  test('trackPageview accepts extra eventData and props arguments', async function (assert) {
+    let plausibleService = this.owner.lookup('service:plausible');
+
+    mockPlausiblePackage(plausibleService);
+
+    plausibleService.enable({
+      domain: 'foo.test',
+    });
+
+    const eventData = {
+      url: 'https://foo-bar.baz',
+    };
+    const props = { foo: 'bar' };
+    plausibleService.trackPageview(eventData, props);
+
+    assert.ok(plausibleService._plausible.trackPageview.calledOnce);
+
+    const callArgs = plausibleService._plausible.trackPageview.firstCall.args;
+    assert.strictEqual(
+      callArgs.at(0),
+      eventData,
+      'it passes the eventData argument into the trackPageview util'
+    );
+    assert.strictEqual(
+      callArgs.at(1)?.props,
+      props,
+      'it passes the props argument as options.props to the trackPageview util'
+    );
+  });
+
   test('it has a trackEvent method that calls the same method on the wrapped package', async function (assert) {
     let plausibleService = this.owner.lookup('service:plausible');
 
@@ -111,6 +141,36 @@ module('Unit | Service | plausible', function (hooks) {
     plausibleService.trackEvent('foo');
 
     assert.ok(plausibleService._plausible.trackEvent.calledOnce);
+    assert.ok(plausibleService._plausible.trackEvent.calledWith('foo'));
+  });
+
+  test('trackEvent accepts extra props and eventData arguments', async function (assert) {
+    let plausibleService = this.owner.lookup('service:plausible');
+
+    mockPlausiblePackage(plausibleService);
+
+    plausibleService.enable({
+      domain: 'foo.test',
+    });
+
+    const eventData = {
+      url: 'https://foo-bar.baz',
+    };
+    const props = { foo: 'bar' };
+    plausibleService.trackEvent('foo', props, eventData);
+
+    assert.ok(plausibleService._plausible.trackEvent.calledOnce);
+    const callArgs = plausibleService._plausible.trackEvent.firstCall.args;
+    assert.strictEqual(
+      callArgs.at(1)?.props,
+      props,
+      'it passes the props argument as options.props to the trackPageview util'
+    );
+    assert.strictEqual(
+      callArgs.at(2),
+      eventData,
+      'it passes the eventData argument into the trackPageview util'
+    );
   });
 
   test('it cleans up any active autotrackers when the service is destroyed', async function (assert) {


### PR DESCRIPTION
This allows users to pass any extra `eventData` or `props` to the `trackPageview` and `trackEvent` methods.

Closes #29 